### PR TITLE
Add support for `NA`, `Inf`, and `NaN`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nombre
 Title: Number Names
-Version: 0.4.0
+Version: 0.4.0.9000
 Authors@R: 
     c(person(given = "Alexander",
              family = "Rossell Hayes",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # nombre (development version)
 
+* Non-finite inputs (`NA`, `Inf`, and `NaN`) no longer produce an error.
+  - `Inf` is handled like a normal number. `nom_card(Inf)` produces `"infinity"` and `nom_ord(Inf)` produces `"infinitieth"`.
+  - `NA` and `NaN` propogate through functions. All functions return `NA` for `NA` and `"NaN"` for `NaN`.
+
 # nombre 0.4.0
 
 * Added `ratio()`, which generates ratios.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Non-finite inputs (`NA`, `Inf`, and `NaN`) no longer produce an error.
   - `Inf` is handled like a normal number. `nom_card(Inf)` produces `"infinity"` and `nom_ord(Inf)` produces `"infinitieth"`.
-  - `NA` and `NaN` propogate through functions. All functions return `NA` for `NA` and `"NaN"` for `NaN`.
+  - `NA` and `NaN` propagate through functions. All functions return `NA` for `NA` and `"NaN"` for `NaN`.
 
 # nombre 0.4.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# nombre (development version)
+
 # nombre 0.4.0
 
 * Added `ratio()`, which generates ratios.

--- a/R/adverbial.R
+++ b/R/adverbial.R
@@ -13,23 +13,30 @@
 #' @example examples/adverbial.R
 
 adverbial <- function(x, thrice = FALSE, ...) {
-  if (!length(x))          return(character(0))
-  if (!is.numeric(x))      stop("`x` must be a numeric vector")
-  if (length(thrice) != 1) stop("`thrice` must be length one")
+  if (!length(x))                 return(character(0))
+  if (all(is.na(x) & !is.nan(x))) return(as.character(x))
+  if (!is.numeric(x))             stop("`x` must be a numeric vector")
+  if (length(thrice) != 1)        stop("`thrice` must be length one")
   if (!is.logical(thrice) | is.na(thrice))
     stop("`thrice` must be either `TRUE` or `FALSE`")
 
   numeric <- x
+  na      <- is.na(x)
 
-  adv              <- paste(cardinal(x, ...), "time")
-  adv[abs(x) != 1] <- paste0(adv[abs(x) != 1], "s")
+  adv                    <- paste(cardinal(x, ...), "time")
+  adv[!na & abs(x) != 1] <- paste0(adv[!na & abs(x) != 1], "s")
 
-  adv[abs(x) == 1] <- gsub("one time$", "once", adv[abs(x) == 1])
-  adv[abs(x) == 2] <- gsub("two times$", "twice", adv[abs(x) == 2])
+  adv[!na & abs(x) == 1] <- gsub("one time$", "once", adv[!na & abs(x) == 1])
+  adv[!na & abs(x) == 2] <- gsub("two times$", "twice", adv[!na & abs(x) == 2])
 
   if (thrice) {
-    adv[abs(x) == 3] <- gsub("three times$", "thrice", adv[abs(x) == 3])
+    adv[!na & abs(x) == 3] <- gsub(
+      "three times$", "thrice", adv[!na & abs(x) == 3]
+    )
   }
+
+  adv[is.na(x)]  <- NA
+  adv[is.nan(x)] <- NaN
 
   args        <- as.list(match.call()[-1])
   args[["x"]] <- NULL

--- a/R/collective.R
+++ b/R/collective.R
@@ -18,8 +18,9 @@
 #' @example examples/collective.R
 
 collective <- function(x, all_n = TRUE, of_the = FALSE, cardinal = TRUE, ...) {
-  if (!length(x))     return(character(0))
-  if (!is.numeric(x)) stop("`x` must be a numeric vector")
+  if (!length(x))                 return(character(0))
+  if (all(is.na(x) & !is.nan(x))) return(as.character(x))
+  if (!is.numeric(x))             stop("`x` must be a numeric vector")
 
   numeric <- x
 
@@ -48,6 +49,9 @@ collective <- function(x, all_n = TRUE, of_the = FALSE, cardinal = TRUE, ...) {
   coll[coll == ""] <- "all"
 
   coll <- paste0(coll, n, of)
+
+  coll[is.na(x)]  <- NA
+  coll[is.nan(x)] <- NaN
 
   args        <- as.list(match.call()[-1])
   args[["x"]] <- NULL

--- a/R/convert_fraction.R
+++ b/R/convert_fraction.R
@@ -11,8 +11,10 @@ convert_fraction <- function(
     return(paste(numerator, denominator))
   }
 
-  x[] <- cardinal(
-    x,
+  na <- apply(x, 2, function(x) all(is.na(x)))
+
+  x[, !na] <- cardinal(
+    x[, !na],
     max_n = if (length(max_n) == 1) {
       max_n
     } else {
@@ -24,5 +26,13 @@ convert_fraction <- function(
       rep(negative, each = length(x) / 2)
     }
   )
-  paste(x[1, ], sep, x[2, ])
+
+  result      <- character(ncol(x))
+  result[!na] <- paste(x[1, !na], sep, x[2, !na])
+  result[na]  <- x[1, na]
+  result
+}
+
+is_NAish <- function(x) {
+  is.na(x) | x == "NaN"
 }

--- a/R/denominator.R
+++ b/R/denominator.R
@@ -16,9 +16,10 @@
 #' @example examples/denominator.R
 
 denominator <- function(x, numerator = 1, quarter = TRUE, ...) {
-  if (!length(x))              return(character(0))
-  if (!is.numeric(x))          stop("`x` must be numeric")
-  if (!is.numeric(numerator))  stop("`numerator` must be numeric")
+  if (!length(x))                 return(character(0))
+  if (all(is.na(x) & !is.nan(x))) return(as.character(x))
+  if (!is.numeric(x))             stop("`x` must be numeric")
+  if (!is.numeric(numerator))     stop("`numerator` must be numeric")
   if (length(numerator) != 1 & length(numerator) != length(x))
     stop("`numerator` must be either length one or the same length as `x`")
   if (length(quarter) != 1) stop("`quarter` must be length one")
@@ -26,25 +27,35 @@ denominator <- function(x, numerator = 1, quarter = TRUE, ...) {
     stop("`quarter` must be either `TRUE` or `FALSE`")
 
   numeric <- x
+  finite  <- is.finite(x)
   denom   <- ordinal(x, ...)
   plural  <- abs(numerator) != 1
 
-  denom[abs(x) == 1] <- gsub("1st$|first$", "whole", denom[abs(x) == 1])
-
-  denom[abs(x) == 2 & !plural] <- gsub(
-    "2nd$|second$", "half", denom[abs(x) == 2 & !plural]
+  denom[finite & abs(x) == 1] <- gsub(
+    "1st$|first$", "whole", denom[finite & abs(x) == 1]
   )
-  denom[abs(x) == 2 & plural] <- gsub(
-    "2nd$|second$", "halves", denom[abs(x) == 2 & plural]
+
+  denom[finite & abs(x) == 2 & !plural] <- gsub(
+    "2nd$|second$", "half", denom[finite & abs(x) == 2 & !plural]
+  )
+  denom[finite & abs(x) == 2 & plural] <- gsub(
+    "2nd$|second$", "halves", denom[finite & abs(x) == 2 & plural]
   )
 
   if (quarter) {
-    denom[abs(x) == 4] <- gsub("fourth$", "quarter", denom[abs(x) == 4])
+    denom[finite & abs(x) == 4] <- gsub(
+      "fourth$", "quarter", denom[finite & abs(x) == 4]
+    )
   }
 
-  denom[plural & abs(x) != 2] <- paste0(denom[plural & abs(x) != 2], "s")
+  denom[finite & plural & abs(x) != 2] <- paste0(
+    denom[finite & plural & abs(x) != 2], "s"
+  )
 
   denom <- gsub("^one-", "", denom)
+
+  denom[is.na(x)]  <- NA
+  denom[is.nan(x)] <- NaN
 
   args        <- as.list(match.call()[-1])
   args[["x"]] <- NULL

--- a/R/numerator.R
+++ b/R/numerator.R
@@ -11,7 +11,7 @@
 #' @export
 
 numerator <- function(x, ...) {
-  if (any(x != x %/% 1)) {
+  if (any(x[is.finite(x)] != x[is.finite(x)] %/% 1)) {
     stop("`x` must not have a decimal component when producing a numerator")
   }
 

--- a/R/ordinal.R
+++ b/R/ordinal.R
@@ -22,7 +22,8 @@
 ordinal <- function(
   x, cardinal = TRUE, ...
 ) {
-  if (!length(x)) return(character(0))
+  if (!length(x))                 return(character(0))
+  if (all(is.na(x) & !is.nan(x))) return(as.character(x))
   if (!is.numeric(x) & !is.character(x))
     stop("`x` must be a numeric or character vector")
 
@@ -70,6 +71,9 @@ ordinal <- function(
   ordinal[ordinal == ""] <- paste0(x[ordinal == ""], "th")
 
   ordinal <- gsub(" ", "-", trimws(ordinal))
+
+  ordinal[!is.na(x) & x == "NaN"] <- NaN
+  ordinal[is.na(x)]               <- NA
 
   args        <- as.list(match.call()[-1])
   args[["x"]] <- NULL

--- a/R/ratio.R
+++ b/R/ratio.R
@@ -18,9 +18,10 @@ ratio <- function(x, sep = "in", max_n = Inf, negative = "negative", ...) {
   numeric <- x
   n       <- length(x)
 
-  if (!n)                 return(character(0))
-  if (!is.numeric(x))     stop("`x` must be numeric")
-  if (!is.numeric(max_n)) stop("`max_n` must be numeric")
+  if (!n)                         return(character(0))
+  if (all(is.na(x) & !is.nan(x))) return(as.character(x))
+  if (!is.numeric(x))             stop("`x` must be numeric")
+  if (!is.numeric(max_n))         stop("`max_n` must be numeric")
   if (length(max_n) != 1 && length(max_n) != n)
     stop("`max_n` must be either length one or the same length as `x`")
   if (!is.character(negative)) stop("`negative` must be of type character")

--- a/tests/testthat/test-adverbial.R
+++ b/tests/testthat/test-adverbial.R
@@ -19,7 +19,15 @@ test_that("adverbial max_n", {
   expect_equal(nom_adv(1:2, max_n = 1), c("once", "2 times"))
 })
 
+test_that("non-finite", {
+  expect_equal(
+    nom_adv(c(NA, 2, Inf, NaN, NA)),
+    c(NA, "twice", "infinity times", NaN, NA)
+  )
+})
+
 test_that("early return", {
+  expect_equal(nom_adv(NA), NA_character_)
   expect_equal(nom_adv(numeric(0)), character(0))
 })
 

--- a/tests/testthat/test-cardinal.R
+++ b/tests/testthat/test-cardinal.R
@@ -63,7 +63,15 @@ test_that("decimal cardinal with fracture ...", {
   )
 })
 
+test_that("non-finite", {
+  expect_equal(
+    nom_card(c(NA, 2, Inf, NaN, NA)),
+    c(NA, "two", "infinity", NaN, NA)
+  )
+})
+
 test_that("early return", {
+  expect_equal(nom_card(NA), NA_character_)
   expect_equal(nom_card(numeric(0)), character(0))
   expect_equal(nom_numer(numeric(0)), character(0))
   expect_equal(convert_hundreds(numeric(0)), character(0))

--- a/tests/testthat/test-collective.R
+++ b/tests/testthat/test-collective.R
@@ -28,7 +28,15 @@ test_that("collective all_n", {
   expect_equal(collective(3, all_n = FALSE, of_the = TRUE), "all of the")
 })
 
+test_that("non-finite", {
+  expect_equal(
+    nom_coll(c(NA, 2, Inf, NaN, NA)),
+    c(NA, "both", "all infinity", NaN, NA)
+  )
+})
+
 test_that("early return", {
+  expect_equal(nom_coll(NA), NA_character_)
   expect_equal(nom_coll(numeric(0)), character(0))
 })
 

--- a/tests/testthat/test-denominator.R
+++ b/tests/testthat/test-denominator.R
@@ -46,7 +46,15 @@ test_that("denominator with max_n", {
   )
 })
 
+test_that("non-finite", {
+  expect_equal(
+    nom_denom(c(NA, 2, Inf, NaN, NA)),
+    c(NA, "half", "infinitieth", NaN, NA)
+  )
+})
+
 test_that("early return", {
+  expect_equal(nom_denom(NA), NA_character_)
   expect_equal(nom_denom(numeric(0)), character(0))
 })
 

--- a/tests/testthat/test-ordinal.R
+++ b/tests/testthat/test-ordinal.R
@@ -54,7 +54,15 @@ test_that("ordinal suffixes on character vector", {
   expect_equal(nom_ord("one zillion"), "one-zillionth")
 })
 
+test_that("non-finite", {
+  expect_equal(
+    nom_ord(c(NA, 2, Inf, NaN, NA)),
+    c(NA, "second", "infinitieth", NaN, NA)
+  )
+})
+
 test_that("early return", {
+  expect_equal(nom_ord(NA), NA_character_)
   expect_equal(nom_ord(numeric(0)), character(0))
 })
 

--- a/tests/testthat/test-ratio.R
+++ b/tests/testthat/test-ratio.R
@@ -51,6 +51,7 @@ test_that("ratio with fracture ...", {
 })
 
 test_that("early return", {
+  expect_equal(nom_ratio(NA), NA_character_)
   expect_equal(nom_ratio(numeric(0)), character(0))
 })
 

--- a/tests/testthat/test-ratio.R
+++ b/tests/testthat/test-ratio.R
@@ -51,8 +51,6 @@ test_that("ratio with fracture ...", {
 })
 
 test_that("non-finite", {
-  expect_equal(nom_ratio(c(NA, 2)), c(NA, "two in one"))
-
   skip_if_not_installed("fracture", "0.2.0.9001")
 
   expect_equal(

--- a/tests/testthat/test-ratio.R
+++ b/tests/testthat/test-ratio.R
@@ -51,6 +51,8 @@ test_that("ratio with fracture ...", {
 })
 
 test_that("non-finite", {
+  expect_equal(nom_ratio(c(NA, 2)), c(NA, "two in one"))
+
   skip_if_not_installed("fracture", "0.2.0.9001")
 
   expect_equal(

--- a/tests/testthat/test-ratio.R
+++ b/tests/testthat/test-ratio.R
@@ -51,6 +51,8 @@ test_that("ratio with fracture ...", {
 })
 
 test_that("non-finite", {
+  skip_if_not_installed("fracture", "0.2.0.9001")
+
   expect_equal(
     nom_ratio(c(NA, 2, Inf, NaN, NA)),
     c(NA, "two in one", "infinity in one", NaN, NA)

--- a/tests/testthat/test-ratio.R
+++ b/tests/testthat/test-ratio.R
@@ -50,6 +50,13 @@ test_that("ratio with fracture ...", {
   expect_equal(nom_ratio(15/100, sep = "to", max_denom = 15), "one to seven")
 })
 
+test_that("non-finite", {
+  expect_equal(
+    nom_ratio(c(NA, 2, Inf, NaN, NA)),
+    c(NA, "two in one", "infinity in one", NaN, NA)
+  )
+})
+
 test_that("early return", {
   expect_equal(nom_ratio(NA), NA_character_)
   expect_equal(nom_ratio(numeric(0)), character(0))


### PR DESCRIPTION
``` r
library(nombre)

nom_card(Inf)
#> [1] "infinity"
nom_ord(Inf)
#> [1] "infinitieth"
nom_adv(Inf)
#> [1] "infinity times"

nom_card(NA)
#> [1] NA
nom_card(NaN)
#> [1] "NaN"
```

<sup>Created on 2021-11-02 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #8.