### PR TITLE
Add `cardinal` argument to `adverbial()`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,4 +1,4 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 #
 # NOTE: This workflow is overkill for most R packages and
@@ -14,8 +14,6 @@ name: R-CMD-check
 
 jobs:
   R-CMD-check:
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
-
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
@@ -24,49 +22,42 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
+          - {os: macos-latest,   r: 'release'}
 
           - {os: windows-latest, r: 'release'}
           # Use 3.6 to trigger usage of RTools35
           - {os: windows-latest, r: '3.6'}
+          # use 4.1 to check with rtools40's older compiler
+          - {os: windows-latest, r: '4.1'}
 
-          # Use older ubuntu to maximise backward compatibility
-          - {os: ubuntu-18.04,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-18.04,   r: 'release'}
-          - {os: ubuntu-18.04,   r: 'oldrel-1'}
-          - {os: ubuntu-18.04,   r: 'oldrel-2'}
-          - {os: ubuntu-18.04,   r: 'oldrel-3'}
-          - {os: ubuntu-18.04,   r: 'oldrel-4'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: 'oldrel-2'}
+          - {os: ubuntu-latest,   r: 'oldrel-3'}
+          - {os: ubuntu-latest,   r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: rcmdcheck
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - uses: r-lib/actions/check-r-package@v1
-
-      - name: Show testthat output
-        if: always()
-        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
-        shell: bash
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,34 +1,48 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
     branches: [main, master]
-    tags: ['*']
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
 
 name: pkgdown
 
 jobs:
   pkgdown:
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: pkgdown
+          extra-packages: any::pkgdown, local::.
           needs: website
 
-      - name: Deploy package
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,4 +1,4 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
@@ -10,22 +10,41 @@ name: test-coverage
 
 jobs:
   test-coverage:
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: covr
+          extra-packages: any::covr
+          needs: coverage
 
       - name: Test coverage
-        run: covr::codecov()
+        run: |
+          covr::codecov(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
         shell: Rscript {0}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,5 +27,5 @@ Suggests:
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.3.1
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nombre
 Title: Number Names
-Version: 0.4.1
+Version: 0.4.1.9000
 Authors@R: 
     c(person(given = "Alexander",
              family = "Rossell Hayes",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# nombre (development version)
+
 # nombre 0.4.1
 
 * Non-finite inputs (`NA`, `Inf`, and `NaN`) no longer produce an error.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # nombre (development version)
 
+* `adverbial()` gains a `cardinal` argument like `ordinal()`.
+  - Set `cardinal = FALSE` to add "times" suffixes without converting to cardinal numbers.
+
 # nombre 0.4.1
 
 * Non-finite inputs (`NA`, `Inf`, and `NaN`) no longer produce an error.

--- a/R/adverbial.R
+++ b/R/adverbial.R
@@ -5,6 +5,11 @@
 #'     If `TRUE`, the adverbial of `3` will be "thrice".
 #'     If `FALSE`, the adverbial of `3` will be "three times".
 #'     Defaults to `FALSE`.
+#' @param cardinal Whether to convert a numeric vector with [cardinal()]
+#'     before applying ordinal suffixes.
+#'     When `TRUE`, 1 -> "first".
+#'     When `FALSE`, 1 -> "1st".
+#'     Defaults to `TRUE`.
 #' @param ... Additional arguments passed to [cardinal()]
 #'
 #' @return A character vector of the same length as `x`
@@ -12,7 +17,7 @@
 #' @export
 #' @example examples/adverbial.R
 
-adverbial <- function(x, thrice = FALSE, ...) {
+adverbial <- function(x, thrice = FALSE, cardinal = TRUE, max_n = Inf, ...) {
   if (!length(x))                 return(character(0))
   if (all(is.na(x) & !is.nan(x))) return(as.character(x))
   if (!is.numeric(x))             stop("`x` must be a numeric vector")
@@ -21,27 +26,40 @@ adverbial <- function(x, thrice = FALSE, ...) {
     stop("`thrice` must be either `TRUE` or `FALSE`")
 
   numeric <- x
-  na      <- is.na(x)
+  na <- is.na(x)
 
-  adv <- paste(cardinal(x, ...), "times")
-
-  adv[!na & abs(x) == 1] <- str_replace_all(
-    adv[!na & abs(x) == 1], "one times$", "once"
-  )
-  adv[!na & abs(x) == 2] <- str_replace_all(
-    adv[!na & abs(x) == 2], "two times$", "twice"
-  )
-
-  if (thrice) {
-    adv[!na & abs(x) == 3] <- str_replace_all(
-      adv[!na & abs(x) == 3], "three times$", "thrice"
-    )
+  if (cardinal) {
+    x <- cardinal(x, max_n = max_n, ...)
+  } else {
+    x <- format(x, scientific = FALSE)
   }
 
-  adv[is.na(x)]  <- NA
-  adv[is.nan(x)] <- NaN
+  times <- rep("times", length(x))
+  times[abs(numeric) == 1] <- "time"
+  adv <- paste(x, times)
 
-  args        <- as.list(match.call()[-1])
+  if (cardinal && max_n >= 1) {
+    adv[!na & abs(numeric) == 1] <- str_replace_all(
+      adv[!na & abs(numeric) == 1], "one time$", "once"
+    )
+
+    if (max_n >= 2) {
+      adv[!na & abs(numeric) == 2] <- str_replace_all(
+        adv[!na & abs(numeric) == 2], "two times$", "twice"
+      )
+
+      if (thrice && max_n >= 3) {
+        adv[!na & abs(numeric) == 3] <- str_replace_all(
+          adv[!na & abs(numeric) == 3], "three times$", "thrice"
+        )
+      }
+    }
+  }
+
+  adv[na] <- NA
+  adv[is.nan(numeric)] <- NaN
+
+  args <- as.list(match.call()[-1])
   args[["x"]] <- NULL
 
   structure(

--- a/R/adverbial.R
+++ b/R/adverbial.R
@@ -6,10 +6,15 @@
 #'     If `FALSE`, the adverbial of `3` will be "three times".
 #'     Defaults to `FALSE`.
 #' @param cardinal Whether to convert a numeric vector with [cardinal()]
-#'     before applying ordinal suffixes.
-#'     When `TRUE`, 1 -> "first".
-#'     When `FALSE`, 1 -> "1st".
+#'     before applying adverbial suffixes.
+#'     When `TRUE`, 1 -> "once".
+#'     When `FALSE`, 1 -> "1 time".
 #'     Defaults to `TRUE`.
+#' @param max_n A numeric vector.
+#'     When the absolute value of `x` is greater than `max_n`, `x` remains
+#'     numeric instead of being converted to words.
+#'     If `max_n` is negative, no `x`s will be converted to words.
+#'     Defaults to `Inf`, which converts all `x`s to words.
 #' @param ... Additional arguments passed to [cardinal()]
 #'
 #' @return A character vector of the same length as `x`

--- a/R/ordinal.R
+++ b/R/ordinal.R
@@ -19,9 +19,7 @@
 #' @export
 #' @example examples/ordinal.R
 
-ordinal <- function(
-    x, cardinal = TRUE, ...
-) {
+ordinal <- function(x, cardinal = TRUE, ...) {
   if (!length(x))                 return(character(0))
   if (all(is.na(x) & !is.nan(x))) return(as.character(x))
   if (!is.numeric(x) & !is.character(x))

--- a/man/adverbial.Rd
+++ b/man/adverbial.Rd
@@ -6,11 +6,11 @@
 \alias{nom_times}
 \title{Convert numbers to adverbial character vectors (once, twice, three times)}
 \usage{
-adverbial(x, thrice = FALSE, ...)
+adverbial(x, thrice = FALSE, cardinal = TRUE, max_n = Inf, ...)
 
-nom_adv(x, thrice = FALSE, ...)
+nom_adv(x, thrice = FALSE, cardinal = TRUE, max_n = Inf, ...)
 
-nom_times(x, thrice = FALSE, ...)
+nom_times(x, thrice = FALSE, cardinal = TRUE, max_n = Inf, ...)
 }
 \arguments{
 \item{x}{A numeric vector}
@@ -19,6 +19,18 @@ nom_times(x, thrice = FALSE, ...)
 If \code{TRUE}, the adverbial of \code{3} will be "thrice".
 If \code{FALSE}, the adverbial of \code{3} will be "three times".
 Defaults to \code{FALSE}.}
+
+\item{cardinal}{Whether to convert a numeric vector with \code{\link[=cardinal]{cardinal()}}
+before applying adverbial suffixes.
+When \code{TRUE}, 1 -> "once".
+When \code{FALSE}, 1 -> "1 time".
+Defaults to \code{TRUE}.}
+
+\item{max_n}{A numeric vector.
+When the absolute value of \code{x} is greater than \code{max_n}, \code{x} remains
+numeric instead of being converted to words.
+If \code{max_n} is negative, no \code{x}s will be converted to words.
+Defaults to \code{Inf}, which converts all \code{x}s to words.}
 
 \item{...}{Additional arguments passed to \code{\link[=cardinal]{cardinal()}}}
 }

--- a/nombre.Rproj
+++ b/nombre.Rproj
@@ -18,6 +18,5 @@ LineEndingConversion: Posix
 
 BuildType: Package
 PackageUseDevtools: Yes
-PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace

--- a/tests/testthat/test-adverbial.R
+++ b/tests/testthat/test-adverbial.R
@@ -4,6 +4,12 @@ test_that("simple adverbial", {
   expect_equal(nom_adv(4), "four times")
 })
 
+test_that("simple adverbial uncardinalized", {
+  expect_equal(nom_adv(1, cardinal = FALSE), "1 time")
+  expect_equal(nom_adv(2, cardinal = FALSE), "2 times")
+  expect_equal(nom_adv(4, cardinal = FALSE), "4 times")
+})
+
 test_that("adverbial vector", {
   expect_equal(nom_adv(1:2), c("once", "twice"))
   expect_equal(nom_adv(4:5), c("four times", "five times"))

--- a/tests/testthat/test-uncardinal.R
+++ b/tests/testthat/test-uncardinal.R
@@ -11,7 +11,9 @@ test_that("uncardinal", {
     -1000:1e4,
     sample(c(1, -1), 1e4, replace = TRUE) * 10 ^ runif(1e4, 5, 15.95) %/% 1
   )
-  expect_equal(uncardinal(as.character(cardinal(x))), x)
+
+  cardinal_x <- suppressWarnings(cardinal(x))
+  expect_equal(uncardinal(as.character(cardinal_x)), x)
 })
 
 test_that("uncardinal with class nombre", {


### PR DESCRIPTION
* `adverbial()` gains a `cardinal` argument like `ordinal()`.
  - Set `cardinal = FALSE` to add "times" suffixes without converting to cardinal numbers.

``` r
library(nombre)
adverbial(1:5, cardinal = FALSE)
#> [1] "1 time"  "2 times" "3 times" "4 times" "5 times"
```

<sup>Created on 2024-03-14 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>